### PR TITLE
Add syntax highlighting to authenticator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install cookie-auth
 
 You **must** pass in your own 'authenticator' function that looks like this:
 
-```
+```javascript
 function authenticator(req, res, cb) {
   // do auth with req, res and call cb when done
   


### PR DESCRIPTION
Added `javascript` syntax highlighting to the authenticator example in README.md
